### PR TITLE
Fix deployment warnings

### DIFF
--- a/src/templates/finops-hub/modules/Microsoft.DataFactory/factories/.bicep/nested_roleAssignments.bicep
+++ b/src/templates/finops-hub/modules/Microsoft.DataFactory/factories/.bicep/nested_roleAssignments.bicep
@@ -51,7 +51,7 @@ var builtInRoleNames = {
 }
 
 resource dataFactory 'Microsoft.DataFactory/factories@2018-06-01' existing = {
-  name: last(split(resourceId, '/'))
+  name: last(split(resourceId, '/'))!
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = [for principalId in principalIds: {

--- a/src/templates/finops-hub/modules/Microsoft.DataFactory/factories/deploy.bicep
+++ b/src/templates/finops-hub/modules/Microsoft.DataFactory/factories/deploy.bicep
@@ -166,7 +166,7 @@ var identity = identityType != 'None' ? {
 var enableReferencedModulesTelemetry = false
 
 resource cMKKeyVault 'Microsoft.KeyVault/vaults@2021-10-01' existing = if (!empty(cMKKeyVaultResourceId)) {
-  name: last(split(cMKKeyVaultResourceId, '/'))
+  name: last(split(cMKKeyVaultResourceId, '/'))!
   scope: resourceGroup(split(cMKKeyVaultResourceId, '/')[2], split(cMKKeyVaultResourceId, '/')[4])
 }
 

--- a/src/templates/finops-hub/modules/Microsoft.KeyVault/vaults/.bicep/nested_roleAssignments.bicep
+++ b/src/templates/finops-hub/modules/Microsoft.KeyVault/vaults/.bicep/nested_roleAssignments.bicep
@@ -61,7 +61,7 @@ var builtInRoleNames = {
 }
 
 resource keyVault 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
-  name: last(split(resourceId, '/'))
+  name: last(split(resourceId, '/'))!
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = [for principalId in principalIds: {

--- a/src/templates/finops-hub/modules/datasets/adlsv2.bicep
+++ b/src/templates/finops-hub/modules/datasets/adlsv2.bicep
@@ -26,39 +26,38 @@ param compressionCodec string = 'gzip'
 @description('Required. Name of the dataset.')
 var datasetName = replace('${containerName}_${datasetType}', '-', '_') // ADLS Gen2 object names can't have hyphens
 
-var csvProps = {       
-                  columnDelimiter: ','
-                  compressionCodec: compressionCodec
-                  compressionLevel: 'Optimal'
-                  escapeChar: '"'
-                  firstRowAsHeader: true
-                  quoteChar: '"' 
-                }
-var parquetProps = { 
-                      compressionCodec: compressionCodec
-                    }
-var commonProps =  {
-                      location: {
-                        type: 'AzureBlobFSLocation'
-                        fileName: {
-                          value: '@{dataset().fileName}'
-                          type: 'Expression'
-                        }
-                        folderPath: {
-                          value: '@{dataset().folderName}'
-                          type: 'Expression'
-                        }
-                      }
-                    }
+var csvProps = {
+  columnDelimiter: ','
+  compressionCodec: compressionCodec
+  compressionLevel: 'Optimal'
+  escapeChar: '"'
+  firstRowAsHeader: true
+  quoteChar: '"'
+}
+var parquetProps = {
+  compressionCodec: compressionCodec
+}
+var commonProps = {
+  location: {
+    type: 'AzureBlobFSLocation'
+    fileName: {
+      value: '@{dataset().fileName}'
+      type: 'Expression'
+    }
+    folderPath: {
+      value: '@{dataset().folderName}'
+      type: 'Expression'
+    }
+  }
+}
 
 var typeProperties = union(commonProps, datasetType == 'Parquet' ? parquetProps : csvProps)
-
 
 resource dataFactoryRef 'Microsoft.DataFactory/factories@2018-06-01' existing = {
   name: dataFactoryName
 }
 
-resource dataset 'Microsoft.DataFactory/factories/datasets@2018-06-01' =  {
+resource dataset 'Microsoft.DataFactory/factories/datasets@2018-06-01' = {
   name: datasetName
   parent: dataFactoryRef
   properties: {
@@ -71,7 +70,7 @@ resource dataset 'Microsoft.DataFactory/factories/datasets@2018-06-01' =  {
         type: 'String'
       }
     }
-    type: datasetType
+    type: any(datasetType)
     typeProperties: typeProperties
     linkedServiceName: {
       parameters: {}


### PR DESCRIPTION
<!--
⚠️⚠️⚠️ BEFORE YOU SUBMIT ⚠️⚠️⚠️
1. Make sure you have a user-friendly PR title that describes the change (this will be in the release notes).
2. Complete all TODO items below and remove the TODO lines after.
3. Internal PRs: Add applicable labels: Type, Micro PR, Breaking change

**PRO TIP**: Smaller PRs are closed faster. Try submitting multiple, small PRs.
-->

## 🛠️ Description
Fixes various build warnings:
- ...\src\templates\finops-hub\modules\datasets\adlsv2.bicep(74,11) : Warning BCP225: The discriminator property "type" value cannot be determined at compilation time. Type checking for this object is disabled.
- ...\src\templates\finops-hub\modules\Microsoft.DataFactory\factories\deploy.bicep(169,9) : Warning BCP321: Expected a value of type "string" but the provided value is of type "null | string".
- ...\src\templates\finops-hub\modules\Microsoft.KeyVault\vaults.bicep\nested_roleAssignments.bicep(64,9) : Warning BCP321: Expected a value of type "string" but the provided value is of type "null | string".
- ...\src\templates\finops-hub\modules\Microsoft.DataFactory\factories.bicep\nested_roleAssignments.bicep(54,9) : Warning BCP321: Expected a value of type "string" but the provided value is of type "null | string".

Fixes #124

## 🔬 How has this been tested?
<!-- TODO: Check [x] all that apply. Leave the rest. -->
- [ ] 🫰 PS -WhatIf / az validate
- [x] 👍 Manually deployed + verified
- [ ] 💪 Unit tests
