### PR TITLE
Add fabricbot policy to flag PRs against main

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1,0 +1,48 @@
+{
+  "version": "1.0",
+  "tasks": [
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "eventType": "pull_request",
+        "eventNames": ["pull_request", "issues", "project_card"],
+        "taskName": "Do not allow PRs to be merged into main",
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "name": "prTargetsBranch",
+              "parameters": {
+                "branchName": "main"
+              }
+            }
+          ]
+        },
+        "actions": [
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "Hi @${issueAuthor}. We noticed you created this PR against `main`. We don't accept PRs against `main`. Please use `dev` or a `features/*` branch instead. To learn more, see [Select a branch](https://github.com/microsoft/cloud-hubs/tree/dev/src#-select-a-branch)."
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Needs: Attention 👋"
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "userGroups": []
+}


### PR DESCRIPTION
<!--
⚠️⚠️⚠️ BEFORE YOU SUBMIT ⚠️⚠️⚠️
1. Make sure you have a user-friendly PR title that describes the change (this will be in the release notes).
2. Complete all TODO items below and remove the TODO lines after.
3. Internal PRs: Add applicable labels: Type, Micro PR, Breaking change

**PRO TIP**: Smaller PRs are closed faster. Try submitting multiple, small PRs.
-->

## 🛠️ Description
Testing a fabricbot policy to not allow PRs against main
