### PR TITLE
Add VS Code build and deploy tasks

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy Hub",
+            "type": "PowerShell",
+            "request": "launch",
+            "script": "./Deploy-Toolkit finops-hub -Build",
+            "cwd": "${workspaceFolder}/src/scripts",
+            "presentation": {
+                "hidden": false,
+                "group": "",
+                "order": 1,
+            },
+        },
+    ],
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,28 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Build Toolkit",
+            "type": "shell",
+            "command": "./Build-Toolkit",
+            "options": {
+                "cwd": "${workspaceFolder}/src/scripts",
+            },
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": true,
+            },
+            "isBackground": false,
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": true,
+                "clear": false,
+            },
+        }
+    ]
+}


### PR DESCRIPTION
<!--
⚠️⚠️⚠️ BEFORE YOU SUBMIT ⚠️⚠️⚠️
1. Make sure you have a user-friendly PR title that describes the change (this will be in the release notes).
2. Complete all TODO items below and remove the TODO lines after.
3. Internal PRs: Add applicable labels: Type, Micro PR, Breaking change

**PRO TIP**: Smaller PRs are closed faster. Try submitting multiple, small PRs.
-->

## 🛠️ Description
Adds build and deploy (or run) tasks into VS Code.

The build task is available as a <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>B</kbd> shortcut or via the `Run Task` command.

![Screenshot of the Run Task command in VS Code](https://github.com/microsoft/cloud-hubs/assets/399533/3bd7bde7-7896-4d27-9ac1-4cd375c9a713)

The deploy task is available as a <kbd>F5</kbd> or <kbd>Ctrl</kbd>+<kbd>F5</kbd> shortcuts or via the Run and Debug pane. The behavior is the same regardless of which shortcut you use. The output is in the terminal pane and the run/debug mode will close automatically when the deployment finishes.

![Screenshot of the deployment running in VS Code](https://github.com/microsoft/cloud-hubs/assets/399533/db53f9c4-0e12-4899-b593-b630f5626186)

## 🔬 How has this been tested?
<!-- TODO: Check [x] all that apply. Leave the rest. -->
- [ ] 🫰 PS -WhatIf / az validate
- [x] 👍 Manually deployed + verified
- [ ] 💪 Unit tests
